### PR TITLE
Added foot and pelvis controllers

### DIFF
--- a/config/controllers.yaml
+++ b/config/controllers.yaml
@@ -33,6 +33,11 @@ controller_list:
       - LHipRoll
       - LHipPitch
       - LKneePitch
+  - name: nao_dcm/LeftFoot_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
       - LAnklePitch
       - LAnkleRoll
   - name: nao_dcm/RightLeg_controller
@@ -43,14 +48,19 @@ controller_list:
       - RHipRoll
       - RHipPitch
       - RKneePitch
+  - name: nao_dcm/RightFoot_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
       - RAnklePitch
       - RAnkleRoll
-#  - name: nao/Pelvis_controller
-#    action_ns: follow_joint_trajectory
-#    type: FollowJointTrajectory
-#    default: true
-#    joints:
-#      - LHipYawPitch
+  - name: nao_dcm/Pelvis_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
+      - LHipYawPitch
   - name: nao_dcm/LeftHand_controller
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory

--- a/config/fake_controllers.yaml
+++ b/config/fake_controllers.yaml
@@ -15,11 +15,16 @@ controller_list:
     joints:
       - HeadYaw
       - HeadPitch
+  - name: fake_Pelvis_controller
+    joints:
+      - LHipYawPitch
   - name: fake_LeftLeg_controller
     joints:
       - LHipRoll
       - LHipPitch
       - LKneePitch
+  - name: fake_LeftFoot_controller
+    joints:
       - LAnklePitch
       - LAnkleRoll
   - name: fake_RightLeg_controller
@@ -27,11 +32,10 @@ controller_list:
       - RHipRoll
       - RHipPitch
       - RKneePitch
+  - name: fake_RightFoot_controller
+    joints:
       - RAnklePitch
       - RAnkleRoll
-#  - name: fake_Pelvis_controller
-#    joints:
-#      - LHipYawPitch
   - name: fake_LeftHand_controller
     joints:
       - LWristYaw
@@ -40,60 +44,3 @@ controller_list:
     joints:
       - RWristYaw
       - RHand
-#  - name: fake_LeftArmWithHand_controller
-#    joints:
-#       - LShoulderPitch
-#       - LShoulderRoll
-#       - LElbowYaw
-#       - LElbowRoll
-#       - LWristYaw
-#       - LHand
-#   - name: fake_RightArmWithHand_controller
-#     joints:
-#       - RShoulderPitch
-#       - RShoulderRoll
-#       - RElbowYaw
-#       - RElbowRoll
-#       - RWristYaw
-#       - RHand
-#  - name: fake_EntireBody_controller
-#    joints:
-#      - LHipYawPitch
-#      - LHipRoll
-#      - LHipPitch
-#      - LKneePitch
-#      - LAnklePitch
-#      - LAnkleRoll
-#      - RHipRoll
-#      - RHipPitch
-#      - RKneePitch
-#      - RAnklePitch
-#      - RAnkleRoll
-#      - HeadYaw
-#      - HeadPitch
-#      - LShoulderPitch
-#      - LShoulderRoll
-#      - LElbowYaw
-#      - LElbowRoll
-#      - LWristYaw
-#      - LHand
-#      - RShoulderPitch
-#      - RShoulderRoll
-#      - RElbowYaw
-#      - RElbowRoll
-#      - RWristYaw
-#      - RHand
-#  - name: fake_left_endeffector_controller
-#    joints:
-#      - LHand
-#  - name: fake_right_endeffector_controller
-#    joints:
-#      - RHand
-#  - name: fake_right_foot_effector_controller
-#    joints:
-#      - RAnklePitch
-#      - RAnkleRoll
-#  - name: fake_left_foot_effector_controller
-#    joints:
-#      - LAnklePitch
-#      - LAnkleRoll

--- a/launch/moveit_planner.launch
+++ b/launch/moveit_planner.launch
@@ -1,13 +1,8 @@
 <?xml version="1.0"?>
 <launch>
     <arg name="version" value="V40"/>
-    <!-- Call Nao Robot publisher -->
-    <include file="$(find nao_description)/launch/nao_desc_generated.launch">
-        <arg name="version" value="$(arg version)"/>
-    </include>
 	
     <!-- Start move_group -->
-
  	<include file="$(find nao_moveit_config)/launch/move_group.launch">
  		<arg name="publish_monitored_planning_scene" value="true" />
 	</include>


### PR DESCRIPTION
Added foot and pelvis controllers in coupling with https://github.com/ros-naoqi/nao_virtual/pull/8 . Also, removed nao robot publisher from being launched in moveit_planner.launch. I believe it is not needed. If someone needs the robot publisher for a certain application, he can always launch it separately or create a new launch file..
