### PR TITLE
solving a problem of namespace (nao_dcm/joint_states) and move_group

### DIFF
--- a/launch/move_group.launch
+++ b/launch/move_group.launch
@@ -39,6 +39,7 @@
 
   <!-- Start the actual move_group node/action server -->
   <node name="move_group" launch-prefix="$(arg launch_prefix)" pkg="moveit_ros_move_group" type="move_group" respawn="false" output="screen" args="$(arg command_args)">
+    <remap from="/joint_states" to="/nao_dcm/joint_states" />
     <!-- Set the display variable, in case OpenGL code is used internally -->
     <env name="DISPLAY" value="$(optenv DISPLAY :0)" />
 


### PR DESCRIPTION
Finally, it solves the problem of namespace !!! :) please accept it, otherwise Moveit will not read robot's "joint_states" since they are in "nao_dcm" namespace 
